### PR TITLE
Improve TUI navigation

### DIFF
--- a/DIFF_20250722_054226.md
+++ b/DIFF_20250722_054226.md
@@ -1,0 +1,6 @@
+## Changes on $(date -u '+%Y-%m-%d %H:%M UTC')
+- Added About and Messages screens to RepoToolApp with new keyboard bindings.
+- Integrated tests for opening About and Message Center screens.
+- Updated README with new shortcuts.
+- Removed unsupported Diagnostic screen to avoid import errors.
+- Replaced FilteredDataTable with DataTable in MessageCenterScreen for Textual 4 compatibility.

--- a/DIFF_20250722_054233.md
+++ b/DIFF_20250722_054233.md
@@ -1,0 +1,6 @@
+## Changes on 2025-07-22 05:42 UTC
+- Added About and Messages screens to RepoToolApp with new keyboard bindings.
+- Integrated tests for opening About and Message Center screens.
+- Updated README with new shortcuts.
+- Removed unsupported Diagnostic screen to avoid import errors.
+- Replaced FilteredDataTable with DataTable in MessageCenterScreen for Textual 4 compatibility.

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ repo-tool
    - Press 'q' to quit
    - Press 'r' to refresh repository list
    - Press 's' for settings
+   - Press 'a' for about
+   - Press 'g' for messages
    - Use 'space' to select repositories
    - Press 'd' to download selected repositories
 

--- a/RECOMMENDATIONS_20250722_054237.md
+++ b/RECOMMENDATIONS_20250722_054237.md
@@ -1,0 +1,4 @@
+## Recommendations 2025-07-22
+- Pin the textual dependency to a version that supports widgets used by the TUI or update the code accordingly.
+- Expand unit tests to cover repository management and message analytics features.
+- Consider providing a minimal config for headless environments to run the application without network tokens.

--- a/src/repo_tool/tui/about_screen.py
+++ b/src/repo_tool/tui/about_screen.py
@@ -181,7 +181,8 @@ class AboutScreen(Screen):
             license_path = Path(__file__).parent.parent.parent / "LICENSE"
             with open(license_path) as f:
                 license_text = f.read()
-                
+
             from .text_screen import TextScreen
             self.app.push_screen(TextScreen("License", license_text))
-
+        except Exception as e:
+            self.notify(f"Failed to open license: {e}", severity="error")

--- a/src/repo_tool/tui/app.py
+++ b/src/repo_tool/tui/app.py
@@ -25,6 +25,8 @@ from pathlib import Path
 import threading
 from ..core.logger import setup_logger
 from .repo_screen import RepoManagementScreen
+from .about_screen import AboutScreen
+from .message_screen import MessageCenterScreen
 
 # ASCII art logo
 LOGO = """
@@ -48,6 +50,8 @@ class RepoToolApp(App):
         Binding("m", "manage", "Manage Repositories", show=True),
         Binding("space", "toggle_select", "Select Repo", show=True),
         Binding("d", "download", "Download", show=True),
+        Binding("a", "about", "About", show=True),
+        Binding("g", "messages", "Messages", show=True),
     ]
 
     current_repo = reactive("")
@@ -112,6 +116,14 @@ class RepoToolApp(App):
     def action_manage(self) -> None:
         """Show repository management screen"""
         self.push_screen(RepoManagementScreen())
+
+    def action_about(self) -> None:
+        """Show about screen"""
+        self.push_screen(AboutScreen())
+
+    def action_messages(self) -> None:
+        """Show message center screen"""
+        self.push_screen(MessageCenterScreen())
 
     def action_toggle_select(self) -> None:
         """Toggle selection of highlighted repository"""

--- a/src/repo_tool/tui/message_screen.py
+++ b/src/repo_tool/tui/message_screen.py
@@ -8,7 +8,6 @@ from textual.widgets import (
     Button,
     DataTable,
     Label,
-    FilteredDataTable,
     Tabs,
     Tab,
     Footer
@@ -45,7 +44,7 @@ class MessageCenterScreen(Screen):
                 id="message-tabs"
             ),
             ScrollableContainer(
-                FilteredDataTable(
+                DataTable(
                     show_header=True,
                     zebra_stripes=True,
                     id="message-table"
@@ -57,7 +56,7 @@ class MessageCenterScreen(Screen):
         
     def on_mount(self) -> None:
         """Handle screen mount"""
-        table = self.query_one("#message-table", FilteredDataTable)
+        table = self.query_one("#message-table", DataTable)
         table.add_columns(
             "Time",
             "Type",
@@ -69,7 +68,7 @@ class MessageCenterScreen(Screen):
         
     def load_messages(self, message_type: MessageType = None) -> None:
         """Load messages into the table"""
-        table = self.query_one("#message-table", FilteredDataTable)
+        table = self.query_one("#message-table", DataTable)
         table.clear()
         
         # Get messages from the last 7 days by default
@@ -128,7 +127,7 @@ class MessageCenterScreen(Screen):
         
     def action_filter(self) -> None:
         """Toggle filter input"""
-        table = self.query_one("#message-table", FilteredDataTable)
+        table = self.query_one("#message-table", DataTable)
         table.focus()
         
     def on_data_table_row_selected(self, event: DataTable.RowSelected) -> None:

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -19,3 +19,41 @@ def test_settings_screen_opens():
 
     asyncio.run(run_app())
 
+
+def test_about_screen_opens():
+    async def run_app():
+        import keyring
+        storage = {}
+        keyring.set_password = lambda s, u, p: storage.__setitem__((s, u), p)
+        keyring.get_password = lambda s, u: storage.get((s, u))
+        keyring.delete_password = lambda s, u: storage.pop((s, u), None)
+
+        app = RepoToolApp()
+        app.token_manager.has_valid_tokens = lambda: True
+        async with app.run_test() as pilot:
+            app.action_about()
+            await pilot.pause(0.1)
+            assert app.screen_stack[-1].__class__.__name__ == 'AboutScreen'
+
+    asyncio.run(run_app())
+
+
+def test_message_center_opens():
+    async def run_app():
+        import keyring
+        storage = {}
+        keyring.set_password = lambda s, u, p: storage.__setitem__((s, u), p)
+        keyring.get_password = lambda s, u: storage.get((s, u))
+        keyring.delete_password = lambda s, u: storage.pop((s, u), None)
+
+        app = RepoToolApp()
+        app.token_manager.has_valid_tokens = lambda: True
+        async with app.run_test() as pilot:
+            app.action_messages()
+            await pilot.pause(0.1)
+            assert app.screen_stack[-1].__class__.__name__ == 'MessageCenterScreen'
+
+    asyncio.run(run_app())
+
+
+


### PR DESCRIPTION
## Summary
- add About and Message Center screens to the main app
- update README with new shortcuts
- adjust message screen to use DataTable
- add tests for About and Message Center
- include change and recommendations docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f2361baec832a89858a1c447428a7

## Summary by Sourcery

Improve TUI navigation by introducing About and Message Center screens, updating keyboard bindings and documentation, replacing deprecated DataTable widget usage for compatibility, and adding relevant tests and exception handling.

New Features:
- Add About screen accessible via 'a' key binding
- Add Message Center screen accessible via 'g' key binding

Enhancements:
- Replace FilteredDataTable with DataTable in Message Center for Textual 4 compatibility
- Add exception handling when opening the LICENSE file in AboutScreen
- Update README with new shortcuts for About and Messages

Documentation:
- Include change logs and recommendations documents

Tests:
- Add unit tests for opening About and Message Center screens

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced About and Messages screens, accessible via new keyboard shortcuts.
  * Updated documentation to include the new keyboard shortcuts.

* **Bug Fixes**
  * Improved error handling when displaying the license in the About screen.

* **Refactor**
  * Replaced the FilteredDataTable with DataTable in the Messages screen for compatibility.

* **Tests**
  * Added integration tests to verify opening of the About and Messages screens.

* **Chores**
  * Removed the Diagnostic screen to prevent errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->